### PR TITLE
PulseAudio: Add a "Default" sink and source

### DIFF
--- a/src/hostapi/pulseaudio/pa_linux_pulseaudio_cb.c
+++ b/src/hostapi/pulseaudio/pa_linux_pulseaudio_cb.c
@@ -541,18 +541,39 @@ PaError PaPulseAudio_StartStreamCb( PaStream * s )
                                                                         outDevice]) );
             }
 
-            pa_stream_connect_playback( stream->outStream,
-                                        l_ptrPulseAudioHostApi->
-                                        pulseaudioDeviceNames[stream->outDevice],
-                                        &stream->bufferAttr,
-                                        PA_STREAM_INTERPOLATE_TIMING |
-                                        PA_STREAM_ADJUST_LATENCY |
-                                        PA_STREAM_AUTO_TIMING_UPDATE |
-                                        PA_STREAM_NO_REMIX_CHANNELS |
-                                        PA_STREAM_NO_REMAP_CHANNELS |
-                                        PA_STREAM_DONT_MOVE,
-                                        NULL,
-                                        NULL );
+            PaDeviceIndex defaultOutputDevice;
+            PaError result = PaUtil_DeviceIndexToHostApiDeviceIndex(
+                    &defaultOutputDevice,
+                    l_ptrPulseAudioHostApi->inheritedHostApiRep.info.defaultOutputDevice,
+                    &(l_ptrPulseAudioHostApi->inheritedHostApiRep) );
+            if(result == paNoError && stream->outDevice == defaultOutputDevice )
+            {
+                pa_stream_connect_playback( stream->outStream,
+                                            NULL,
+                                            &stream->bufferAttr,
+                                            PA_STREAM_INTERPOLATE_TIMING |
+                                            PA_STREAM_ADJUST_LATENCY |
+                                            PA_STREAM_AUTO_TIMING_UPDATE,
+                                            NULL,
+                                            NULL );
+
+            }
+            else
+            {
+
+                pa_stream_connect_playback( stream->outStream,
+                                            l_ptrPulseAudioHostApi->
+                                            pulseaudioDeviceNames[stream->outDevice],
+                                            &stream->bufferAttr,
+                                            PA_STREAM_INTERPOLATE_TIMING |
+                                            PA_STREAM_ADJUST_LATENCY |
+                                            PA_STREAM_AUTO_TIMING_UPDATE |
+                                            PA_STREAM_NO_REMIX_CHANNELS |
+                                            PA_STREAM_NO_REMAP_CHANNELS |
+                                            PA_STREAM_DONT_MOVE,
+                                            NULL,
+                                            NULL );
+            }
 
             pa_stream_set_underflow_callback( stream->outStream,
                                               PaPulseAudio_StreamUnderflowCb,
@@ -578,16 +599,33 @@ PaError PaPulseAudio_StartStreamCb( PaStream * s )
                                                                     inDevice]));
         }
 
-        pa_stream_connect_record( stream->inStream,
-                                  l_ptrPulseAudioHostApi->
-                                  pulseaudioDeviceNames[stream->inDevice],
-                                  &stream->bufferAttr,
-                                  PA_STREAM_INTERPOLATE_TIMING |
-                                  PA_STREAM_ADJUST_LATENCY |
-                                  PA_STREAM_AUTO_TIMING_UPDATE |
-                                  PA_STREAM_NO_REMIX_CHANNELS |
-                                  PA_STREAM_NO_REMAP_CHANNELS |
-                                  PA_STREAM_DONT_MOVE);
+        PaDeviceIndex defaultInputDevice;
+        PaError result = PaUtil_DeviceIndexToHostApiDeviceIndex(
+                &defaultInputDevice,
+                l_ptrPulseAudioHostApi->inheritedHostApiRep.info.defaultInputDevice,
+                &(l_ptrPulseAudioHostApi->inheritedHostApiRep) );
+        if ( result == paNoError && stream->inDevice == defaultInputDevice )
+        {
+            pa_stream_connect_record( stream->inStream,
+                                      NULL,
+                                      &stream->bufferAttr,
+                                      PA_STREAM_INTERPOLATE_TIMING |
+                                      PA_STREAM_ADJUST_LATENCY |
+                                      PA_STREAM_AUTO_TIMING_UPDATE);
+        }
+        else 
+        {
+            pa_stream_connect_record( stream->inStream,
+                                      l_ptrPulseAudioHostApi->
+                                      pulseaudioDeviceNames[stream->inDevice],
+                                      &stream->bufferAttr,
+                                      PA_STREAM_INTERPOLATE_TIMING |
+                                      PA_STREAM_ADJUST_LATENCY |
+                                      PA_STREAM_AUTO_TIMING_UPDATE |
+                                      PA_STREAM_NO_REMIX_CHANNELS |
+                                      PA_STREAM_NO_REMAP_CHANNELS |
+                                      PA_STREAM_DONT_MOVE);
+        }
         pa_stream_set_underflow_callback( stream->inStream,
                                           PaPulseAudio_StreamUnderflowCb,
                                           stream);

--- a/src/hostapi/pulseaudio/pa_linux_pulseaudio_internal.h
+++ b/src/hostapi/pulseaudio/pa_linux_pulseaudio_internal.h
@@ -96,8 +96,7 @@ typedef struct
     PaHostApiIndex hostApiIndex;
     PaDeviceInfo deviceInfoArray[PAPULSEAUDIO_MAX_DEVICECOUNT];
     char *pulseaudioDeviceNames[PAPULSEAUDIO_MAX_DEVICECOUNT];
-    char pulseaudioDefaultSource[PAPULSEAUDIO_MAX_DEVICENAME];
-    char pulseaudioDefaultSink[PAPULSEAUDIO_MAX_DEVICENAME];
+    pa_sample_spec pulseaudioDefaultSampleSpec;
 
     /* PulseAudio stuff goes here */
     pa_threaded_mainloop *mainloop;


### PR DESCRIPTION
This exposes the API, the "pulse" ALSA device offers as well. 

* Client Applications will just use the "Default" device that is just configured in Pulse.
* The device is changed with the system setting, for instance if a user connects a Laptop to a HDMI TV
* You can remap the device using pavucontrol 

This is matched my use case with Mixxx at home as and a alternative to the explicite selection of the devices, that is respected by Pulse. The later I will use when connected to a PA system where automatically remapping is undesired. 