### PR TITLE
PulseAudio: Fix audio timestamp calculation.

### DIFF
--- a/src/hostapi/pulseaudio/pa_linux_pulseaudio_cb.c
+++ b/src/hostapi/pulseaudio/pa_linux_pulseaudio_cb.c
@@ -97,11 +97,11 @@ void PaPulseAudio_updateTimeInfo( pa_stream * s,
   {
       if( record == 0 )
       {
-          timeInfo->outputBufferDacTime = ((PaTime) l_lStreamLatency / (PaTime) 1000000);
+          timeInfo->outputBufferDacTime = timeInfo->currentTime + ((PaTime) l_lStreamLatency / (PaTime) 1000000);
       }
       else
       {
-          timeInfo->inputBufferAdcTime = ((PaTime) l_lStreamLatency / (PaTime) 1000000);
+          timeInfo->inputBufferAdcTime = timeInfo->currentTime - ((PaTime) l_lStreamLatency / (PaTime) 1000000);
       }
   }
 


### PR DESCRIPTION
timeInfo.outputBufferDacTime and outputBufferAdcTime are absolute
time values, not latency offsets, so calculate their absolute time
values by addint or subtracting reported stream latencies from
calculated timeInfo.currentTime.

Testing shows that this gives correct results and consistent time
reporting (e.g., in the paCallback()) with the reporting done for
the ALSA host api and JACK host api.

Signed-off-by: Mario Kleiner <mario.kleiner.de@gmail.com>